### PR TITLE
Separate some process into test code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.15.0"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3face7de38293a2f7e2a9f69a48b442f28e864da0fc7a6a977388e31bdc367d7"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -633,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "b9d0183f6f6001549ab68f8c7585093bb732beefbcf6d23a10b9b95c73a1dd49"
 dependencies = [
  "autocfg",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,7 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636aafcdd74940530a9ea644e3def456b493ec42fdd0bd2bb1ae3338b2032849"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -259,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
@@ -466,6 +464,8 @@ dependencies = [
  "base64 0.13.0",
  "bdk",
  "bitcoin 0.25.2",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -542,18 +542,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk = { version = "0.16.0", features = ["keys-bip39"] }
+# bdk = { version = "0.16.0", features = ["keys-bip39"] }
+bdk = { path = "../bdk", features = ["keys-bip39"] }
 bitcoin = "0.25.0"
 base64 = "0.13.0"
+serde = "1.0.136"
+serde_json = "1.0.78"
+
+[dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# bdk = { version = "0.16.0", features = ["keys-bip39"] }
-bdk = { path = "../bdk", features = ["keys-bip39"] }
+bdk = { version = "0.16.1", features = ["keys-bip39"] }
 bitcoin = "0.25.0"
 base64 = "0.13.0"
 serde = "1.0.136"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lastly, each Alice and Bob sign the trasaction by their own prive key.
 
 # Initial setup
 
-```
+```rust
 // Start regtest bitcoind and electrs
 // To stop bitcoind, run "make stop-bitcoind"
 make run-servers
@@ -29,18 +29,35 @@ bitcoin-cli --regtest sendtoaddress bcrt1q7hv0uc8pun3u9vex4lxvf9tev8qxdn68pw6r30
 ```
 
 If electrs is waiting for IBD, you need to mine a block.  
-```
+```shell
 $ [electrs::daemon] waiting for 0 blocks to download (IBD)
 ```
 
-```
+```shell
 bitcoin-cli --regtest generatetodescriptor 1 "wpkh(tprv8ZgxMBicQKsPcwmRJonpDgQecfz4yQ29EzGoJE8gdo22yhWZHJVdWcatkKTy28CqGxnfuyZmaVeehVb52RPJVc1qrs8dVR6uQvcZwWdcX5w/84h/1h/0h/0/0)"
 ```
 
 # Run
-Use regtest server on your local.
+## Prepare utxos as client
+
+This will dump utxos to ./data/client/utxos 
+```shell
+cargo test dump_utxo -- --nocapture
 ```
+
+## Construct PSBT as server
+This will dump unsigned PSBT as ./data/psbt.txt
+```shell
 HOST="127.0.0.1:50001" NETWORK="regtest" cargo run
+```
+
+For test net
+```shell
 HOST="ssl://blockstream.info:993" NETWORK="testnet" cargo run
 HOST="ssl://electrum.blockstream.info:60002" NETWORK="testnet" cargo run
 ```
+
+## Sign PSBT as client
+```shell
+cargo test sign_psbt -- --nocapture
+``


### PR DESCRIPTION
Finally we want to separate server process and client process.
At this time I chose to use test coed as client process to make thing simple.

A few improvement in README.